### PR TITLE
Add undistort config and functionality

### DIFF
--- a/introspective_ORB_SLAM/Examples/Stereo/stereo_kitti.cc
+++ b/introspective_ORB_SLAM/Examples/Stereo/stereo_kitti.cc
@@ -54,7 +54,7 @@ ORB_SLAM2::System *SLAM_ptr;
 DEFINE_string(vocab_path, "", "Path to ORB vocabulary.");
 DEFINE_string(settings_path, "", "Path to ORB-SLAM config file.");
 DEFINE_string(data_path, "", "Path to the source dataset.");
-DEFINE_int32(session, -1, "Unique session ID.");
+DEFINE_string(session, "", "Unique session ID.");
 DEFINE_string(ground_truth_path, "", "Path to ground truth poses.");
 DEFINE_string(img_qual_path,
               "",
@@ -155,7 +155,7 @@ void CheckCommandLineArgs(char **argv) {
 }
 
 void LoadImages(const string &strPathToSequence,
-                const int &sessionID,
+                const string &session,
                 vector<string> &vstrImageLeft,
                 vector<string> &vstrImageRight,
                 vector<double> &vTimestamps);
@@ -163,7 +163,7 @@ void LoadImages(const string &strPathToSequence,
 // Loads images as well as the corresponding predicted image quality heatmaps
 void LoadImagesWithQual(const string &strPathToSequence,
                         const string &strPathToImageQual,
-                        const int &sessionID,
+                        const string &session,
                         vector<string> &vstrImageLeft,
                         vector<string> &vstrImageRight,
                         vector<string> &vstrImageQualFilenames,
@@ -174,7 +174,7 @@ void LoadImagesWithGT(const string &strPathToSequence,
                       const string &strPathToGroundTruth,
                       const string &strPathToImageQual,
                       const string &strPathToPoseUncertainty,
-                      const int &sessionID,
+                      const string &session,
                       const bool &load_pose_uncertainty,
                       vector<string> &vstrImageLeft,
                       vector<string> &vstrImageRight,
@@ -627,12 +627,13 @@ int main(int argc, char **argv) {
 }
 
 void LoadImages(const string &strPathToSequence,
-                const int &session,
+                const string &session,
                 vector<string> &vstrImageLeft,
                 vector<string> &vstrImageRight,
                 vector<double> &vTimestamps) {
   ifstream fTimes;
-  string strPathTimeFile = strPathToSequence + "/" + std::to_string(session) +"_times.txt";
+  string strPathTimeFile = strPathToSequence + "/" + session +"_times.txt";
+  std::cout << strPathTimeFile << std::endl;
   fTimes.open(strPathTimeFile.c_str());
   while (!fTimes.eof()) {
     string s;
@@ -664,13 +665,14 @@ void LoadImages(const string &strPathToSequence,
 
 void LoadImagesWithQual(const string &strPathToSequence,
                         const string &strPathToImageQual,
-                        const int &session,
+                        const string &session,
                         vector<string> &vstrImageLeft,
                         vector<string> &vstrImageRight,
                         vector<string> &vstrImageQualFilenames,
                         vector<double> &vTimestamps) {
   ifstream fTimes;
-  string strPathTimeFile = strPathToSequence + "/" + std::to_string(session) +"_times.txt";
+  string strPathTimeFile = strPathToSequence + "/" + session +"_times.txt";
+  std::cout << strPathTimeFile << std::endl;
   fTimes.open(strPathTimeFile.c_str());
   while (!fTimes.eof()) {
     string s;
@@ -724,7 +726,7 @@ void LoadImagesWithGT(const string &strPathToSequence,
                       const string &strPathToGroundTruth,
                       const string &strPathToImageQual,
                       const string &strPathToPoseUncertainty,
-                      const int &session,
+                      const string &session,
                       const bool &load_pose_uncertainty,
                       vector<string> &vstrImageLeft,
                       vector<string> &vstrImageRight,
@@ -733,7 +735,8 @@ void LoadImagesWithGT(const string &strPathToSequence,
                       vector<cv::Mat> *cam_pose_gt,
                       vector<Eigen::Vector2f> *rel_cam_pose_uncertainty) {
   ifstream fTimes;
-  string strPathTimeFile = strPathToSequence + "/" + std::to_string(session) +"_times.txt";
+  string strPathTimeFile = strPathToSequence + "/" + session +"_times.txt";
+  std::cout << strPathTimeFile << std::endl;
   fTimes.open(strPathTimeFile.c_str());
   while (!fTimes.eof()) {
     string s;

--- a/introspective_ORB_SLAM/Examples/Stereo/stereo_kitti.cc
+++ b/introspective_ORB_SLAM/Examples/Stereo/stereo_kitti.cc
@@ -306,8 +306,8 @@ int main(int argc, char **argv) {
                                 M1r,
                                 M2r);
   } else if (FLAGS_rectify_images) {
-    D_l = cv::Mat::eye(1, 4, CV_32F);
-    D_r = cv::Mat::eye(1, 4, CV_32F);
+    D_l = cv::Mat::zeros(1, 4, CV_32F);
+    D_r = cv::Mat::zeros(1, 4, CV_32F);
 
     cv::initUndistortRectifyMap(K_l,
                                 D_l,

--- a/introspective_ORB_SLAM/src/feature_evaluator.cpp
+++ b/introspective_ORB_SLAM/src/feature_evaluator.cpp
@@ -284,20 +284,12 @@ void FeatureEvaluator::LoadRectificationMap(const std::string& calib_file) {
   int rows_l = file["LEFT.height"];
   int cols_l = file["LEFT.width"];
 
-  if (K_l.empty() || P_l.empty() || R_l.empty() || rows_l == 0 || cols_l == 0) {
-    LOG(WARNING) << "Required parameters for image rectification were not "
+  if (K_l.empty() || P_l.empty() || R_l.empty() || D_l.empty() || rows_l == 0 || cols_l == 0) {
+    LOG(WARNING) << "Required parameters for image undistortion/rectification were not "
                  << "found in the calibration file. Generated training "
-                 << "heatmaps will not be unrectified.";
+                 << "heatmaps cannot be undistorted/rectified.";
     rectification_map_available_ = false;
     return;
-  }
-
-  // The unrectification is currently only supported for undistorted images
-  if (!D_l.empty()) {
-    if (cv::countNonZero(D_l) > 0) {
-      LOG(FATAL) << "Heatmap unrectification is not currently supported for "
-                 << "distorted images.";
-    }
   }
 
   cv::Mat R_l_inv;
@@ -311,6 +303,7 @@ void FeatureEvaluator::LoadRectificationMap(const std::string& calib_file) {
                               unrect_map1_left_,
                               unrect_map2_left_);
   rectification_map_available_ = true;
+  return;
 }
 
 std::vector<cv::KeyPoint> FeatureEvaluator::GetMatchedKeyPoints() {

--- a/introspective_ORB_SLAM/src/feature_evaluator.cpp
+++ b/introspective_ORB_SLAM/src/feature_evaluator.cpp
@@ -284,21 +284,14 @@ void FeatureEvaluator::LoadRectificationMap(const std::string& calib_file) {
   int rows_l = file["LEFT.height"];
   int cols_l = file["LEFT.width"];
 
-  if (K_l.empty() || P_l.empty() || R_l.empty() || rows_l == 0 || cols_l == 0) {
-    LOG(WARNING) << "Required parameters for image rectification were not "
+  if (K_l.empty() || P_l.empty() || R_l.empty() || D_l.empty() || rows_l == 0 || cols_l == 0) {
+    LOG(WARNING) << "Required parameters for image undistortion/rectification were not "
                  << "found in the calibration file. Generated training "
                  << "heatmaps will not be unrectified.";
     rectification_map_available_ = false;
     return;
   }
 
-  // The unrectification is currently only supported for undistorted images
-  if (!D_l.empty()) {
-    if (cv::countNonZero(D_l) > 0) {
-      LOG(FATAL) << "Heatmap unrectification is not currently supported for "
-                 << "distorted images.";
-    }
-  }
 
   cv::Mat R_l_inv;
   cv::transpose(R_l, R_l_inv);
@@ -1060,22 +1053,18 @@ void FeatureEvaluator::SaveImagesToFile(std::string target_path,
     RemoveDirectory(target_path + "/feature_qual/");
     RemoveDirectory(target_path + "/feature_matching/");
     RemoveDirectory(target_path + "/bad_matched_features/");
-    RemoveDirectory(target_path + "/bad_region_heatmap/");
     RemoveDirectory(target_path + "/bad_region_heatmap_vis/");
     RemoveDirectory(target_path + "/bad_region_heatmap_masked_vis/");
     RemoveDirectory(target_path + "/reprojection_err_vec/");
     RemoveDirectory(target_path + "/epipolar_err_vec/");
-    RemoveDirectory(target_path + "/err_norm_factor/");
     CreateDirectory(target_path);
     CreateDirectory(target_path + "/feature_qual/");
     CreateDirectory(target_path + "/feature_matching/");
     CreateDirectory(target_path + "/bad_matched_features/");
-    CreateDirectory(target_path + "/bad_region_heatmap/");
     CreateDirectory(target_path + "/bad_region_heatmap_vis/");
     CreateDirectory(target_path + "/bad_region_heatmap_masked_vis/");
     CreateDirectory(target_path + "/reprojection_err_vec/");
     CreateDirectory(target_path + "/epipolar_err_vec/");
-    CreateDirectory(target_path + "/err_norm_factor/");
   }
 
   string feature_qual_path =
@@ -1084,8 +1073,6 @@ void FeatureEvaluator::SaveImagesToFile(std::string target_path,
       target_path + "/feature_matching/" + img_name_truncated + ".jpg";
   string bad_matched_features_path =
       target_path + "/bad_matched_features/" + img_name_truncated + ".jpg";
-  string bad_region_heatmap_path =
-      target_path + "/bad_region_heatmap/" + img_name_truncated + ".jpg";
   string bad_region_heatmap_vis_path =
       target_path + "/bad_region_heatmap_vis/" + img_name_truncated + ".jpg";
   string bad_region_heatmap_masked_vis_path =
@@ -1095,8 +1082,6 @@ void FeatureEvaluator::SaveImagesToFile(std::string target_path,
       target_path + "/reprojection_err_vec/" + img_name_truncated + ".jpg";
   string epipolar_err_vec_path =
       target_path + "/epipolar_err_vec/" + img_name_truncated + ".jpg";
-  string err_norm_factor_path =
-      target_path + "/err_norm_factor/" + img_name_truncated + ".jpg";
 
   cv::Mat tmp_img = GetFeatureErrVisualization();
   bool reproj_err_available = DrawReprojectionErrVec();
@@ -1105,7 +1090,6 @@ void FeatureEvaluator::SaveImagesToFile(std::string target_path,
   // cv::imwrite(feature_qual_path, img_feature_qual_annotation_);
   // cv::imwrite(feature_matching_path, img_matching_annotation_);
   // cv::imwrite(bad_matched_features_path, img_bad_matching_annotation_);
-  // cv::imwrite(bad_region_heatmap_path, bad_region_heatmap_);
 
   if (kSaveColoredHeatmaps || kSaveColoredMaskedHeatmaps) {
     Scalar flag_color;
@@ -1170,16 +1154,6 @@ void FeatureEvaluator::SaveImagesToFile(std::string target_path,
     }
     cv::imwrite(epipolar_err_vec_path, img_epipolar_err_vec_);
   }
-
-  // Visualize the error normalization factors if available
-  //   if (!err_norm_factor_.empty()) {
-  //     ColorKeypoints(img_err_normalization_factor_,
-  //                         keypts2_select_,
-  //                         err_norm_factor_,
-  //                         10000.0 * 0.005 * 0.064 , // 10000.0 * 0.005^2
-  //                         5.0);
-  //     cv::imwrite(err_norm_factor_path, img_err_normalization_factor_);
-  //   }
 
   first_call = false;
 }


### PR DESCRIPTION
So now that the undistort option is removed from legoloam2kitti I moved it to IV_SLAM. 

I wish there was a more eloquent way to do it, but my relative unfamiliarity with opencv means that I just followed your example. Eager to hear your feedback and ready to move onto the next issue. 